### PR TITLE
Reuse the player, world, cell instances in Client

### DIFF
--- a/agarnet/client.py
+++ b/agarnet/client.py
@@ -195,7 +195,7 @@ class Client(object):
             self.subscriber.on_cell_info(
                 cid=cid, x=cx, y=cy, size=csize, name=cname, color=color,
                 is_virus=is_virus, is_agitated=is_agitated)
-            cells[cid].__init__(
+            cells[cid].update(
                 cid=cid, x=cx, y=cy, size=csize, name=cname, color=color,
                 is_virus=is_virus, is_agitated=is_agitated)
 

--- a/agarnet/client.py
+++ b/agarnet/client.py
@@ -242,7 +242,7 @@ class Client(object):
             self.player.own_ids.clear()
             self.subscriber.on_respawn()
         # server sends empty name, assumes we set it here
-        self.player.world.cells[cid].name = self.player.nick
+        self.world.cells[cid].name = self.player.nick
         self.player.own_ids.add(cid)
         self.player.cells_changed()
         self.subscriber.on_own_id(cid=cid)
@@ -254,8 +254,8 @@ class Client(object):
         bottom = buf.pop_float64()
         self.subscriber.on_world_rect(
             left=left, top=top, right=right, bottom=bottom)
-        self.player.world.top_left = Vec(top, left)
-        self.player.world.bottom_right = Vec(bottom, right)
+        self.world.top_left = Vec(top, left)
+        self.world.bottom_right = Vec(bottom, right)
         self.player.center = self.world.center
 
     def parse_spectate_update(self, buf):
@@ -278,7 +278,7 @@ class Client(object):
     def parse_clear_cells(self, buf):
         # TODO clear cells packet is untested
         self.subscriber.on_clear_cells()
-        self.player.world.cells.clear()
+        self.world.cells.clear()
         self.player.own_ids.clear()
         self.player.cells_changed()
 

--- a/agarnet/client.py
+++ b/agarnet/client.py
@@ -102,7 +102,8 @@ class Client(object):
             self.send_token(self.token)
 
         old_nick = self.player.nick
-        self.player = Player()
+        self.player.reset()
+        self.world.reset()
         self.player.nick = old_nick
         return True
 

--- a/agarnet/world.py
+++ b/agarnet/world.py
@@ -9,7 +9,7 @@ class Cell(object):
         self.cid = cid
         self.pos = Vec(x, y)
         self.size = size
-        self.mass = size**2 / 100.0
+        self.mass = size ** 2 / 100.0
         self.name = getattr(self, 'name', name) or name
         self.color = tuple(map(lambda rgb: rgb / 255.0, color))
         self.is_virus = is_virus
@@ -105,8 +105,14 @@ class Player(object):
     def is_spectating(self):
         return not self.is_alive
 
-    # @property
-    # def visible_area(self):
-    #     """Calculated like in the vanilla client."""
-    #     raise NotImplementedError
-    #     return Vec(), Vec()
+    @property
+    def visible_area(self):
+        """
+        Calculated like in the official client.
+        Returns (top_left, bottom_right).
+        """
+        # looks like zeach has a nice big screen
+        half_viewport = Vec(1920, 1080) / 2 / self.scale
+        top_left = self.world.center - half_viewport
+        bottom_right = self.world.center + half_viewport
+        return top_left, bottom_right

--- a/agarnet/world.py
+++ b/agarnet/world.py
@@ -5,12 +5,13 @@ from .vec import Vec
 
 class Cell(object):
     def __init__(self, *args, **kwargs):
+        self.pos = Vec()
         self.update(*args, **kwargs)
 
     def update(self, cid=-1, x=0, y=0, size=0, name='',
                color=(1, 0, 1), is_virus=False, is_agitated=False):
         self.cid = cid
-        self.pos = Vec(x, y)
+        self.pos.set(x, y)
         self.size = size
         self.mass = size ** 2 / 100.0
         self.name = getattr(self, 'name', name) or name
@@ -42,14 +43,19 @@ class Cell(object):
 
 class World(object):
     def __init__(self):
-        self.reset()
-
-    def reset(self):
         self.cells = defaultdict(Cell)
         self.leaderboard_names = []
         self.leaderboard_groups = []
         self.top_left = Vec(0, 0)
         self.bottom_right = Vec(0, 0)
+        self.reset()
+
+    def reset(self):
+        self.cells.clear()
+        self.leaderboard_names.clear()
+        self.leaderboard_groups.clear()
+        self.top_left.set(0, 0)
+        self.bottom_right.set(0, 0)
 
     @property
     def center(self):
@@ -77,10 +83,11 @@ class World(object):
 class Player(object):
     def __init__(self):
         self.world = World()
+        self.own_ids = set()
         self.reset()
 
     def reset(self):
-        self.own_ids = set()
+        self.own_ids.clear()
         self.nick = ''
         self.center = self.world.center
         self.cells_changed()

--- a/agarnet/world.py
+++ b/agarnet/world.py
@@ -42,6 +42,9 @@ class Cell(object):
 
 class World(object):
     def __init__(self):
+        self.reset()
+
+    def reset(self):
         self.cells = defaultdict(Cell)
         self.leaderboard_names = []
         self.leaderboard_groups = []
@@ -74,12 +77,13 @@ class World(object):
 class Player(object):
     def __init__(self):
         self.world = World()
+        self.reset()
+
+    def reset(self):
         self.own_ids = set()
         self.nick = ''
-        self.scale = 1
         self.center = self.world.center
-        self.total_size = 0
-        self.total_mass = 0
+        self.cells_changed()
 
     def cells_changed(self):
         self.total_size = sum(cell.size for cell in self.own_cells)

--- a/agarnet/world.py
+++ b/agarnet/world.py
@@ -4,8 +4,11 @@ from .vec import Vec
 
 
 class Cell(object):
-    def __init__(self, cid=-1, x=0, y=0, size=0, name='',
-                 color=(1, 0, 1), is_virus=False, is_agitated=False):
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+
+    def update(self, cid=-1, x=0, y=0, size=0, name='',
+               color=(1, 0, 1), is_virus=False, is_agitated=False):
         self.cid = cid
         self.pos = Vec(x, y)
         self.size = size

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.insert(0, '/home/gjum/src/agarnet/')
-
 from unittest import TestCase
 
 from agarnet.client import Client

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.insert(0, '/home/gjum/src/agarnet/')
-
 from unittest import TestCase
 
 from agarnet.utils import find_server, get_party_address

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,0 +1,74 @@
+from unittest import TestCase
+
+from agarnet.vec import Vec
+from agarnet.world import Cell, Player, World
+
+
+screen = Vec(1920, 1080)
+zero = Vec(0, 0)
+
+
+class WindowMock:
+    def __init__(self, tl=Vec(-10, 10), br=Vec(-10, 10)):
+        self.tl = tl
+        self.br = br
+        self.world_center = (br + tl) / 2
+        self.screen_center = screen / 2
+        self.screen_scale = 1
+
+    # taken from gagar, same as in official client
+    def screen_to_world_pos(self, screen_pos):
+        return (screen_pos - self.screen_center) \
+            .idiv(self.screen_scale).iadd(self.world_center)
+
+
+class CellTest(TestCase):
+    def test_lt(self):
+        self.assertLess(Cell(1), Cell(2))
+        self.assertLess(Cell(2, size=10), Cell(1, size=11))
+
+
+class WorldTest(TestCase):
+    def test_world(self):
+        World()  # TODO WorldTest
+
+
+class PlayerTest(TestCase):
+    def test_visible_area(self):
+        player = Player()
+
+        # simple test
+
+        win = WindowMock()
+
+        player.scale = win.screen_scale
+        player.world.top_left = win.tl
+        player.world.bottom_right = win.br
+
+        ptl, pbr = player.visible_area
+
+        rtl = win.screen_to_world_pos(zero)
+        rbr = win.screen_to_world_pos(screen)
+
+        self.assertAlmostEqual(ptl.x, rtl.x)
+        self.assertAlmostEqual(ptl.y, rtl.y)
+        self.assertAlmostEqual(pbr.x, rbr.x)
+        self.assertAlmostEqual(pbr.y, rbr.y)
+
+        # complex test
+
+        win = WindowMock(Vec(123, 234), Vec(-34.5, 45.6))
+
+        player.scale = win.screen_scale = 2.3
+        player.world.top_left = win.tl
+        player.world.bottom_right = win.br
+
+        ptl, pbr = player.visible_area
+
+        rtl = win.screen_to_world_pos(zero)
+        rbr = win.screen_to_world_pos(screen)
+
+        self.assertAlmostEqual(ptl.x, rtl.x)
+        self.assertAlmostEqual(ptl.y, rtl.y)
+        self.assertAlmostEqual(pbr.x, rbr.x)
+        self.assertAlmostEqual(pbr.y, rbr.y)


### PR DESCRIPTION
Adds `update` and `reset` methods to all world objects and uses them in `Client`, so they are not recreated.

Closes #1.

Also adds/fixes some tests and finally implements `Player.visible_area`.
